### PR TITLE
Use alpine version of docker image to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-alpine
 
 COPY . /code
 


### PR DESCRIPTION
## Description

This makes the image about 240M instead of 1.24GB

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change

## Summary by Sourcery

Build:
- Use `python:3-alpine` as a base image.