### PR TITLE
Swap docker away from alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3
 
 COPY . /code
 


### PR DESCRIPTION
## Description

There is an issue with build packages that depend on rustc

Error loading shared library libgcc_s.so.1: No such file or directory (needed by /root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo)