### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,6 @@
 name: Docker Image CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/canterbury-air-patrol/smm-mavlink/security/code-scanning/1](https://github.com/canterbury-air-patrol/smm-mavlink/security/code-scanning/1)

The best fix is to explicitly restrict the GITHUB_TOKEN permissions for the workflow. In this Docker image build workflow, GITHUB_TOKEN is not used for anything requiring write access, so the permission should be set to `contents: read` (the minimal necessary to enable code checkout and other basic read-only operations). This permissions block can be added either at the workflow root (applies to all jobs) or just under the `build` job. Since the workflow has only one job, either approach is suitable. To align with best practices and clarity, the fix will add:

```yaml
permissions:
  contents: read
```

at the top level, directly below the workflow `name`, before `on:`, in `.github/workflows/docker-image.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a permissions block with contents: read at the top level of the Docker Image CI workflow