### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -1,4 +1,6 @@
 name: Run Check Code
+permissions:
+  contents: read
 
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/canterbury-air-patrol/smm-mavlink/security/code-scanning/2](https://github.com/canterbury-air-patrol/smm-mavlink/security/code-scanning/2)

To fix this issue, the workflow should define a `permissions` block, following the principle of least privilege. Since the workflow simply checks code (runs a venv and a check script), it doesn't appear to require write access to anything. The minimal safe permission is `contents: read`, which allows the workflow to clone the repository but grants nothing further. This block should be added at the root level (top of the YAML file just under `name:` or `on:`), so that all jobs inherit it.

**What is needed:**
- Add a `permissions:` block, preferably after `name:` (line 1) and before/on the same indentation as `on:`.
- Set `permissions: contents: read` so the workflow and all its jobs have read-only access to repo contents via `GITHUB_TOKEN`.
- No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add minimal permissions block to the GitHub Actions workflow to follow least privilege principle and resolve the code scanning alert

Bug Fixes:
- Fix missing permissions block in workflow as flagged by code scanning

CI:
- Add permissions: contents: read to the checkcode.yml workflow to limit GITHUB_TOKEN to read-only content access